### PR TITLE
Added font size to toast text body

### DIFF
--- a/src/containers/Toast.tsx
+++ b/src/containers/Toast.tsx
@@ -240,7 +240,7 @@ const __styles = (isDark: boolean) =>
     },
     descLabel: {
       color: Color.get('label', isDark),
-      fontSize: 16
+      fontSize: 16,
     },
     backendImage: {
       position: 'absolute',

--- a/src/containers/Toast.tsx
+++ b/src/containers/Toast.tsx
@@ -240,6 +240,7 @@ const __styles = (isDark: boolean) =>
     },
     descLabel: {
       color: Color.get('label', isDark),
+      fontSize: 16
     },
     backendImage: {
       position: 'absolute',


### PR DESCRIPTION
Adding this pull request because the current text body doesn't have a default font size prop, which makes messages in the toast not so legible.

Please kindly look at this in your spare time.