### PR TITLE
🚀 Hotfix: Fix Modal Orientation Crash in React Native 0.77

### DIFF
--- a/src/containers/Dialog.tsx
+++ b/src/containers/Dialog.tsx
@@ -242,7 +242,7 @@ export class Dialog extends React.Component<IProps, IState> {
     const { visible, styles } = this.state;
     const { _OverlayCloseRender, _CardRender } = this;
     return (
-      <Modal transparent={true} visible={visible} animated={false} onShow={this._showModalHandler}>
+      <Modal transparent={true} supportedOrientations={["portrait" , "portrait-upside-down" ,"landscape" ,"landscape-left" , "landscape-right"]} visible={visible} animated={false} onShow={this._showModalHandler}>
         <Animated.View style={StyleSheet.flatten([styles.backgroundContainer, { opacity: this._opacity }])} />
         <_OverlayCloseRender />
         <_CardRender />


### PR DESCRIPTION
Pull Request Description:
This PR resolves a critical crash related to modal orientation in React Native 0.77, where RCTFabricModalHostViewController was causing an UIApplicationInvalidInterfaceOrientation error.

🔧 Fixes & Changes:
Updated supportedOrientations to explicitly allow all necessary orientations:
["portrait", "portrait-upside-down", "landscape", "landscape-left", "landscape-right"].
Ensured modals respect allowed orientations and prevent unexpected crashes.
Verified compatibility with iOS devices running the latest version.
🔥 Why is this urgent?
This issue breaks the app on iOS when displaying modals, making it a blocking bug for production. Immediate merge is recommended to restore stability.

✅ Tested and confirmed working on real devices.

🚀 Requesting an urgent review & merge! 🙏

Let me know if you need any tweaks! 🚀